### PR TITLE
[Fix] 중간테이블 Cascade 이중 처리 수정

### DIFF
--- a/src/main/java/com/example/real_chat/api/command/RoomCommandApiController.java
+++ b/src/main/java/com/example/real_chat/api/command/RoomCommandApiController.java
@@ -32,7 +32,9 @@ public class RoomCommandApiController {
             @PathVariable Long id
     ) {
         roomService.deleteRoom(id);
-        return ResponseEntity.ok(CommonApiResult.createOk("채팅방이 정상적으로 삭제 되었습니다."));
+        return ResponseEntity.ok(CommonApiResult.createOk(
+                "채팅방이 정상적으로 삭제 되었고, 채팅방에 속한 사용자들 모두 채팅방에서 나가졌습니다."
+        ));
     }
 
     @PatchMapping("/{id}")

--- a/src/main/java/com/example/real_chat/api/command/UserCommandApiController.java
+++ b/src/main/java/com/example/real_chat/api/command/UserCommandApiController.java
@@ -29,6 +29,8 @@ public class UserCommandApiController {
             @PathVariable Long id
     ) {
         userCommandService.delete(id);
-        return ResponseEntity.ok(CommonApiResult.createOk("유저가 정상적으로 삭제되었습니다."));
+        return ResponseEntity.ok(CommonApiResult.createOk(
+                "유저가 정상적으로 삭제되었습니다. 추가로 유저가 속한 채팅방에서 유저가 나가졌습니다."
+        ));
     }
 }

--- a/src/main/java/com/example/real_chat/entity/room/ChatRoom.java
+++ b/src/main/java/com/example/real_chat/entity/room/ChatRoom.java
@@ -26,9 +26,6 @@ public class ChatRoom extends BaseTimeEntity {
     @JoinColumn(name = "rootclient_id")
     private RootClient rootClient;
 
-    @OneToMany(mappedBy = "chatRoom", cascade = CascadeType.REMOVE)
-    private List<UserChatRoom> userChatRooms = new ArrayList<>();
-
     public static ChatRoom createRoom(String name, RootClient rootClient) {
         return ChatRoom.builder()
                 .name(name)
@@ -38,15 +35,5 @@ public class ChatRoom extends BaseTimeEntity {
 
     public void update(String name) {
         this.name = name;
-    }
-
-    public void addUserChatRoom(UserChatRoom userChatRoom) {
-        userChatRooms.add(userChatRoom);
-        userChatRoom.setChatRoom(this); // 양방향 관계 설정
-    }
-
-    public void removeUserChatRoom(UserChatRoom userChatRoom) {
-        userChatRooms.remove(userChatRoom);
-        userChatRoom.setChatRoom(null); // 양방향 관계 해제
     }
 }

--- a/src/main/java/com/example/real_chat/service/command/RoomCommandServiceImpl.java
+++ b/src/main/java/com/example/real_chat/service/command/RoomCommandServiceImpl.java
@@ -16,6 +16,7 @@ public class RoomCommandServiceImpl implements RoomCommandService {
     private final RoomRepository roomRepository;
 
     private final RootClientQueryService rootClientQueryService;
+    private final UserChatRoomCommandService userChatRoomCommandService;
 
     @Override
     public Long addRoom(String roomName, Long clientId) {
@@ -34,5 +35,9 @@ public class RoomCommandServiceImpl implements RoomCommandService {
     public void deleteRoom(Long roomId) {
         ChatRoom chatRoom = roomRepository.findById(roomId).orElseThrow();
         roomRepository.delete(chatRoom);
+    }
+
+    private void deleteUserChatRoom(Long roomId) {
+        userChatRoomCommandService.
     }
 }

--- a/src/main/java/com/example/real_chat/service/command/RoomCommandServiceImpl.java
+++ b/src/main/java/com/example/real_chat/service/command/RoomCommandServiceImpl.java
@@ -39,6 +39,6 @@ public class RoomCommandServiceImpl implements RoomCommandService {
     }
 
     private void deleteUserChatRoom(Long roomId) {
-        userChatRoomCommandService.deleteUserChatRoomByChatRoomId(roomId);
+        userChatRoomCommandService.leaveUserChatRoomByChatRoomId(roomId);
     }
 }

--- a/src/main/java/com/example/real_chat/service/command/RoomCommandServiceImpl.java
+++ b/src/main/java/com/example/real_chat/service/command/RoomCommandServiceImpl.java
@@ -35,6 +35,7 @@ public class RoomCommandServiceImpl implements RoomCommandService {
     public void deleteRoom(Long roomId) {
         ChatRoom chatRoom = roomRepository.findById(roomId).orElseThrow();
         roomRepository.delete(chatRoom);
+        deleteUserChatRoom(roomId);
     }
 
     private void deleteUserChatRoom(Long roomId) {

--- a/src/main/java/com/example/real_chat/service/command/RoomCommandServiceImpl.java
+++ b/src/main/java/com/example/real_chat/service/command/RoomCommandServiceImpl.java
@@ -38,6 +38,6 @@ public class RoomCommandServiceImpl implements RoomCommandService {
     }
 
     private void deleteUserChatRoom(Long roomId) {
-        userChatRoomCommandService.
+        userChatRoomCommandService.deleteUserChatRoomByChatRoomId(roomId);
     }
 }

--- a/src/main/java/com/example/real_chat/service/command/UserChatRoomCommandService.java
+++ b/src/main/java/com/example/real_chat/service/command/UserChatRoomCommandService.java
@@ -6,4 +6,5 @@ import com.example.real_chat.entity.user.User;
 public interface UserChatRoomCommandService {
 
     Long joinChatRoom(Long userId, Long chatRoomId);
+    void deleteUserChatRoomByChatRoomId(Long chatRoomId);
 }

--- a/src/main/java/com/example/real_chat/service/command/UserChatRoomCommandService.java
+++ b/src/main/java/com/example/real_chat/service/command/UserChatRoomCommandService.java
@@ -6,5 +6,5 @@ import com.example.real_chat.entity.user.User;
 public interface UserChatRoomCommandService {
 
     Long joinChatRoom(Long userId, Long chatRoomId);
-    void deleteUserChatRoomByChatRoomId(Long chatRoomId);
+    void leaveUserChatRoomByChatRoomId(Long chatRoomId);
 }

--- a/src/main/java/com/example/real_chat/service/command/UserChatRoomCommandServiceImpl.java
+++ b/src/main/java/com/example/real_chat/service/command/UserChatRoomCommandServiceImpl.java
@@ -28,23 +28,19 @@ public class UserChatRoomCommandServiceImpl implements UserChatRoomCommandServic
     public Long joinChatRoom(Long userId, Long chatRoomId) {
         User user = getUser(userId);
         ChatRoom chatRoom = getChatRoom(chatRoomId);
-
-        // 유저가 이미 해당 채팅방에 속해 있는지 확인
+        
         boolean isUserInChatRoom = userChatRoomRepository.existsByUserAndChatRoom(user, chatRoom);
 
         if (!isUserInChatRoom) {
-            // 유저가 채팅방에 속해 있지 않으면 새로운 UserChatRoom 생성 및 저장
             UserChatRoom userChatRoom = new UserChatRoom();
             userChatRoom.setUser(user);
             userChatRoom.setChatRoom(chatRoom);
 
-            // 연관관계 편의 메소드
             user.addUserChatRoom(userChatRoom);
 
             userChatRoomRepository.save(userChatRoom);
             return userChatRoom.getId();
         } else {
-            // 이미 참여 중이라면 필요한 다른 로직 처리 (에러 반환, 메시지 출력 등)
             throw new RuntimeException();
         }
     }

--- a/src/main/java/com/example/real_chat/service/command/UserChatRoomCommandServiceImpl.java
+++ b/src/main/java/com/example/real_chat/service/command/UserChatRoomCommandServiceImpl.java
@@ -49,6 +49,15 @@ public class UserChatRoomCommandServiceImpl implements UserChatRoomCommandServic
         }
     }
 
+    @Override
+    public void deleteUserChatRoomByChatRoomId(Long chatRoomId) {
+        ChatRoom chatRoom = getChatRoom(chatRoomId);
+        List<UserChatRoom> userChatRoom = userChatRoomRepository.findByChatRoom(chatRoom);
+        for (UserChatRoom m : userChatRoom) {
+            userChatRoomRepository.delete(m);
+        }
+    }
+
     private User getUser(Long userId) {
         return userQueryService.getUserById(userId);
     }

--- a/src/main/java/com/example/real_chat/service/command/UserChatRoomCommandServiceImpl.java
+++ b/src/main/java/com/example/real_chat/service/command/UserChatRoomCommandServiceImpl.java
@@ -3,7 +3,6 @@ package com.example.real_chat.service.command;
 import com.example.real_chat.entity.room.ChatRoom;
 import com.example.real_chat.entity.user.User;
 import com.example.real_chat.entity.userChatRoom.UserChatRoom;
-import com.example.real_chat.repository.RoomRepository;
 import com.example.real_chat.repository.UserChatRoomRepository;
 import com.example.real_chat.service.query.RoomQueryService;
 import com.example.real_chat.service.query.UserQueryService;
@@ -46,11 +45,13 @@ public class UserChatRoomCommandServiceImpl implements UserChatRoomCommandServic
     }
 
     @Override
-    public void deleteUserChatRoomByChatRoomId(Long chatRoomId) {
+    public void leaveUserChatRoomByChatRoomId(Long chatRoomId) {
         ChatRoom chatRoom = getChatRoom(chatRoomId);
         List<UserChatRoom> userChatRoom = userChatRoomRepository.findByChatRoom(chatRoom);
 
         for (UserChatRoom m : userChatRoom) {
+            User user = m.getUser();
+            user.removeUserChatRoom(m);
             userChatRoomRepository.delete(m);
         }
     }

--- a/src/main/java/com/example/real_chat/service/command/UserChatRoomCommandServiceImpl.java
+++ b/src/main/java/com/example/real_chat/service/command/UserChatRoomCommandServiceImpl.java
@@ -39,7 +39,6 @@ public class UserChatRoomCommandServiceImpl implements UserChatRoomCommandServic
             userChatRoom.setChatRoom(chatRoom);
 
             // 연관관계 편의 메소드
-            chatRoom.addUserChatRoom(userChatRoom);
             user.addUserChatRoom(userChatRoom);
 
             userChatRoomRepository.save(userChatRoom);

--- a/src/main/java/com/example/real_chat/service/command/UserChatRoomCommandServiceImpl.java
+++ b/src/main/java/com/example/real_chat/service/command/UserChatRoomCommandServiceImpl.java
@@ -28,7 +28,7 @@ public class UserChatRoomCommandServiceImpl implements UserChatRoomCommandServic
     public Long joinChatRoom(Long userId, Long chatRoomId) {
         User user = getUser(userId);
         ChatRoom chatRoom = getChatRoom(chatRoomId);
-        
+
         boolean isUserInChatRoom = userChatRoomRepository.existsByUserAndChatRoom(user, chatRoom);
 
         if (!isUserInChatRoom) {
@@ -49,6 +49,7 @@ public class UserChatRoomCommandServiceImpl implements UserChatRoomCommandServic
     public void deleteUserChatRoomByChatRoomId(Long chatRoomId) {
         ChatRoom chatRoom = getChatRoom(chatRoomId);
         List<UserChatRoom> userChatRoom = userChatRoomRepository.findByChatRoom(chatRoom);
+
         for (UserChatRoom m : userChatRoom) {
             userChatRoomRepository.delete(m);
         }


### PR DESCRIPTION
#21
유저가 채팅방에 들어갈 때 UserChatRoom에 데이터를 추가하고, 유저가 채팅방에 나갈 때 UserChatRoom의 데이터를 삭제하면 됩니다.
채팅방만 생성될 경우 UserChatRoom 데이터가 추가될 필요 없고, 채팅방이 삭제될 경우에 UserChatRoom 데이터가 삭제되면 되기 때문에 Cascade 처리는 User와 UserChatRoom만 하고 ChatRoom과 UserChatRoom 사이에서는 채팅방 삭제에 따른 메소드만 구현하기로 판단했습니다.

그리고 Cascade all이 아닌 remove 처리만 하는 이유는 유저가 생성되더라도 채팅방에 들어가지 않았다면 UserChatRoom에 데이터가 추가될 이유가 없기 때문입니다.