### PR TITLE
삭제되지 않는 데이터 조회 API 삭제

### DIFF
--- a/src/main/java/com/example/real_chat/api/query/RoomQueryApiController.java
+++ b/src/main/java/com/example/real_chat/api/query/RoomQueryApiController.java
@@ -36,14 +36,4 @@ public class RoomQueryApiController {
 
         return ResponseEntity.ok().body(new Result<>(response));
     }
-
-    @GetMapping("/undeleted")
-    public ResponseEntity<Result<List<RoomResponse>>> getUnDeleteRooms() {
-        List<ChatRoom> unDeletedRooms = roomService.getUnDeletedRooms();
-        List<RoomResponse> response = unDeletedRooms.stream()
-                .map(RoomResponse::new)
-                .toList();
-
-        return ResponseEntity.ok().body(new Result<>(response));
-    }
 }

--- a/src/main/java/com/example/real_chat/api/query/UserQueryApiController.java
+++ b/src/main/java/com/example/real_chat/api/query/UserQueryApiController.java
@@ -37,14 +37,4 @@ public class UserQueryApiController {
 
         return ResponseEntity.ok().body(new Result<>(response));
     }
-
-    @GetMapping("/undeleted")
-    public ResponseEntity<Result<List<GetUserResponse>>> getUndeletedUsers() {
-        List<User> users = userQueryService.getUndeletedUsers();
-        List<GetUserResponse> response = users.stream()
-                .map(GetUserResponse::new)
-                .toList();
-
-        return ResponseEntity.ok().body(new Result<>(response));
-    }
 }

--- a/src/main/java/com/example/real_chat/entity/base/BaseTimeEntity.java
+++ b/src/main/java/com/example/real_chat/entity/base/BaseTimeEntity.java
@@ -1,5 +1,6 @@
 package com.example.real_chat.entity.base;
 
+import com.example.real_chat.entity.room.ChatRoom;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,6 +11,7 @@ import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Getter
 @Setter
@@ -25,15 +27,10 @@ public abstract class BaseTimeEntity {
 
     @LastModifiedDate
     private LocalDateTime modifiedDate;
-
-    @Column(name = "deleted_at", columnDefinition = "DATETIME")
-    private LocalDateTime deletedAt;
-
-    public void delete() {
-        this.deletedAt = LocalDateTime.now();
-    }
-
-    public boolean isDeleted() {
-        return this.deletedAt != null;
-    }
 }
+
+//@Override
+//public List<ChatRoom> findUnDeletedRooms() {
+//    return entityManager.createQuery("select m from ChatRoom m where m.deletedAt is null", ChatRoom.class)
+//            .getResultList();
+//}

--- a/src/main/java/com/example/real_chat/entity/base/BaseTimeEntity.java
+++ b/src/main/java/com/example/real_chat/entity/base/BaseTimeEntity.java
@@ -28,9 +28,3 @@ public abstract class BaseTimeEntity {
     @LastModifiedDate
     private LocalDateTime modifiedDate;
 }
-
-//@Override
-//public List<ChatRoom> findUnDeletedRooms() {
-//    return entityManager.createQuery("select m from ChatRoom m where m.deletedAt is null", ChatRoom.class)
-//            .getResultList();
-//}

--- a/src/main/java/com/example/real_chat/entity/rootClient/RootClient.java
+++ b/src/main/java/com/example/real_chat/entity/rootClient/RootClient.java
@@ -4,6 +4,8 @@ import com.example.real_chat.entity.base.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.time.LocalDateTime;
+
 @Entity
 @Getter
 @Builder
@@ -22,6 +24,9 @@ public class RootClient extends BaseTimeEntity {
 
     private String clientName;
 
+    @Column(name = "deleted_at", columnDefinition = "DATETIME")
+    private LocalDateTime deletedAt;
+
     public static RootClient createRootClient(String clientId, String clientPassword, String clientName) {
         return RootClient.builder()
                 .clientId(clientId)
@@ -34,5 +39,13 @@ public class RootClient extends BaseTimeEntity {
         this.clientId = clientId;
         this.clientPassword = clientPassword;
         this.clientName = clientName;
+    }
+
+    public void delete() {
+        this.deletedAt = LocalDateTime.now();
+    }
+
+    public boolean isDeleted() {
+        return this.deletedAt != null;
     }
 }

--- a/src/main/java/com/example/real_chat/repository/RoomRepository.java
+++ b/src/main/java/com/example/real_chat/repository/RoomRepository.java
@@ -11,7 +11,6 @@ public interface RoomRepository {
 
     Optional<ChatRoom> findById(Long id);
     List<ChatRoom> findAll();
-    List<ChatRoom> findUnDeletedRooms();
 
     void delete(ChatRoom chatRoom);
 }

--- a/src/main/java/com/example/real_chat/repository/RoomRepositoryImpl.java
+++ b/src/main/java/com/example/real_chat/repository/RoomRepositoryImpl.java
@@ -35,12 +35,6 @@ public class RoomRepositoryImpl implements RoomRepository {
     }
 
     @Override
-    public List<ChatRoom> findUnDeletedRooms() {
-        return entityManager.createQuery("select m from ChatRoom m where m.deletedAt is null", ChatRoom.class)
-                .getResultList();
-    }
-
-    @Override
     public void delete(ChatRoom chatRoom) {
         if (entityManager.contains(chatRoom)) {
             entityManager.remove(chatRoom); // 만약 이미 영속 상태라면 제거

--- a/src/main/java/com/example/real_chat/repository/UserRepository.java
+++ b/src/main/java/com/example/real_chat/repository/UserRepository.java
@@ -11,7 +11,6 @@ public interface UserRepository {
 
     Optional<User> findById(Long id);
     List<User> findAll();
-    List<User> findUnDeletedUsers();
 
     void delete(User user);
 }

--- a/src/main/java/com/example/real_chat/repository/UserRepositoryImpl.java
+++ b/src/main/java/com/example/real_chat/repository/UserRepositoryImpl.java
@@ -34,12 +34,6 @@ public class UserRepositoryImpl implements UserRepository {
     }
 
     @Override
-    public List<User> findUnDeletedUsers() {
-        return entityManager.createQuery("select u from User u where u.deletedAt is null", User.class)
-                .getResultList();
-    }
-
-    @Override
     public void delete(User user) {
         if (entityManager.contains(user)) {
             entityManager.remove(user); // 만약 이미 영속 상태라면 제거

--- a/src/main/java/com/example/real_chat/service/query/RoomQueryService.java
+++ b/src/main/java/com/example/real_chat/service/query/RoomQueryService.java
@@ -8,5 +8,4 @@ public interface RoomQueryService {
 
     ChatRoom getRoom(Long roomId);
     List<ChatRoom> getAllRooms();
-    List<ChatRoom> getUnDeletedRooms();
 }

--- a/src/main/java/com/example/real_chat/service/query/RoomQueryServiceImpl.java
+++ b/src/main/java/com/example/real_chat/service/query/RoomQueryServiceImpl.java
@@ -25,9 +25,4 @@ public class RoomQueryServiceImpl implements RoomQueryService {
 
     @Override
     public List<ChatRoom> getAllRooms() { return roomRepository.findAll(); }
-
-    @Override
-    public List<ChatRoom> getUnDeletedRooms() {
-        return roomRepository.findUnDeletedRooms();
-    }
 }

--- a/src/main/java/com/example/real_chat/service/query/UserQueryService.java
+++ b/src/main/java/com/example/real_chat/service/query/UserQueryService.java
@@ -8,5 +8,4 @@ public interface UserQueryService {
 
     User getUserById(Long userId);
     List<User> getAllUsers();
-    List<User> getUndeletedUsers();
 }

--- a/src/main/java/com/example/real_chat/service/query/UserQueryServiceImpl.java
+++ b/src/main/java/com/example/real_chat/service/query/UserQueryServiceImpl.java
@@ -27,9 +27,4 @@ public class UserQueryServiceImpl implements UserQueryService {
     public List<User> getAllUsers() {
         return userRepository.findAll();
     }
-
-    @Override
-    public List<User> getUndeletedUsers() {
-        return userRepository.findUnDeletedUsers();
-    }
 }


### PR DESCRIPTION
#38 

- 삭제된 데이터 getAll 로직 제거
- BaseTimeEntity에 있던 
`@Column(name = "deleted_at", columnDefinition = "DATETIME")
    private LocalDateTime deletedAt;` 코드를 제거하고 RootClient 엔티티에 종속화함