### PR TITLE
Fix#34

### DIFF
--- a/src/main/java/com/example/real_chat/api/query/UserChatRoomQueryApiController.java
+++ b/src/main/java/com/example/real_chat/api/query/UserChatRoomQueryApiController.java
@@ -49,9 +49,9 @@ public class UserChatRoomQueryApiController {
 
     @GetMapping("/chat-room/{roomId}/participants")
     public ResponseEntity<Result<List<GetUserReseponse>>> getParticipantsInChatRoom(
-            @PathVariable Long userId
+            @PathVariable Long roomId
     ) {
-        List<UserChatRoom> userList = userChatRoomQueryService.getParticipantsInChatRoom(userId);
+        List<UserChatRoom> userList = userChatRoomQueryService.getParticipantsInChatRoom(roomId);
 
         List<GetUserReseponse> response = userList.stream()
                 .map(GetUserReseponse::new)

--- a/src/main/java/com/example/real_chat/service/command/RootClientCommandServiceImpl.java
+++ b/src/main/java/com/example/real_chat/service/command/RootClientCommandServiceImpl.java
@@ -8,6 +8,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -32,6 +34,11 @@ public class RootClientCommandServiceImpl implements RootClientCommandService {
     @Override
     public void updateRootClient(Long rootClientId, String id, String password, String name) {
         RootClient rootClient = getRootClientOrThrow(rootClientId);
+        
+        id = Optional.ofNullable(id).filter(s -> !s.isBlank()).orElse(rootClient.getClientId());
+        password = Optional.ofNullable(password).filter(s -> !s.isBlank()).orElse(rootClient.getClientPassword());
+        name = Optional.ofNullable(name).filter(s -> !s.isBlank()).orElse(rootClient.getClientName());
+
         rootClient.update(id, password, name);
     }
 

--- a/src/main/java/com/example/real_chat/service/command/RootClientCommandServiceImpl.java
+++ b/src/main/java/com/example/real_chat/service/command/RootClientCommandServiceImpl.java
@@ -34,7 +34,7 @@ public class RootClientCommandServiceImpl implements RootClientCommandService {
     @Override
     public void updateRootClient(Long rootClientId, String id, String password, String name) {
         RootClient rootClient = getRootClientOrThrow(rootClientId);
-        
+
         id = Optional.ofNullable(id).filter(s -> !s.isBlank()).orElse(rootClient.getClientId());
         password = Optional.ofNullable(password).filter(s -> !s.isBlank()).orElse(rootClient.getClientPassword());
         name = Optional.ofNullable(name).filter(s -> !s.isBlank()).orElse(rootClient.getClientName());


### PR DESCRIPTION
```
@Override
    public void updateRootClient(Long rootClientId, String id, String password, String name) {
        RootClient rootClient = getRootClientOrThrow(rootClientId);

        id = Optional.ofNullable(id).filter(s -> !s.isBlank()).orElse(rootClient.getClientId());
        password = Optional.ofNullable(password).filter(s -> !s.isBlank()).orElse(rootClient.getClientPassword());
        name = Optional.ofNullable(name).filter(s -> !s.isBlank()).orElse(rootClient.getClientName());

        rootClient.update(id, password, name);
    }
```
Optional.ofNullable 사용해서 null과 빈 문자열이 들어올 경우 업데이트 하지 않도록 수정.