### PR TITLE
[Fix] @Valid 애노테이션 빠져있어서 추가

### DIFF
--- a/src/main/java/com/example/real_chat/api/command/UserCommandApiController.java
+++ b/src/main/java/com/example/real_chat/api/command/UserCommandApiController.java
@@ -4,6 +4,7 @@ import com.example.real_chat.dto.common.CommonApiResult;
 import com.example.real_chat.dto.user.request.CreateUserRequest;
 import com.example.real_chat.dto.user.response.CreateUserResponse;
 import com.example.real_chat.service.command.UserCommandService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -17,7 +18,7 @@ public class UserCommandApiController {
 
     @PostMapping()
     public ResponseEntity<CreateUserResponse> createUser(
-            @RequestBody CreateUserRequest request
+            @RequestBody @Valid CreateUserRequest request
     ) {
         Long userId = userCommandService.addUser(request.getUserName(), request.getRootClientId());
         return ResponseEntity.ok().body(new CreateUserResponse(userId));


### PR DESCRIPTION
```
@PostMapping()
    public ResponseEntity<CreateUserResponse> createUser(
            @RequestBody @Valid CreateUserRequest request
    ) {
        Long userId = userCommandService.addUser(request.getUserName(), request.getRootClientId());
        return ResponseEntity.ok().body(new CreateUserResponse(userId));
    }
```

CreateUserRequest 매개변수에 @Valid 애노테이션이 붙어있지 않았어서 생겼던 문제로, 추가 이후 해결됨