### PR TITLE
Fix#36

### DIFF
--- a/src/main/java/com/example/real_chat/entity/chat/Resource.java
+++ b/src/main/java/com/example/real_chat/entity/chat/Resource.java
@@ -20,7 +20,7 @@ public abstract class Resource<T> extends BaseTimeEntity {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "room_id")
+    @JoinColumn(name = "chatroom_id")
     private ChatRoom chatRoom;
 
     private String sender;

--- a/src/main/java/com/example/real_chat/entity/user/User.java
+++ b/src/main/java/com/example/real_chat/entity/user/User.java
@@ -11,7 +11,7 @@ import java.util.List;
 
 @Entity
 @Getter
-@Table(name = "memeber") // 에러의 원인은 H2에서 "user"라는 이름이 어떠한 명령어로 예약되어 있기 때문입니다! 따라서 user 테이블을 사용하면, H2는 예약된 명령어라고 에러를 발생시키게 되요. 이를 막기 위해서는 테이블의 이름을 변경할 수도 있고
+@Table(name = "\"User\"")
 public class User extends BaseTimeEntity {
 
     @Id

--- a/src/main/java/com/example/real_chat/service/command/RoomCommandServiceImpl.java
+++ b/src/main/java/com/example/real_chat/service/command/RoomCommandServiceImpl.java
@@ -37,14 +37,15 @@ public class RoomCommandServiceImpl implements RoomCommandService {
     @Override
     public void deleteRoom(Long roomId) {
         ChatRoom chatRoom = getChatRoomOrThrow(roomId);
-        roomRepository.delete(chatRoom);
         deleteUserChatRoom(roomId);
+        roomRepository.delete(chatRoom);
     }
 
     private ChatRoom getChatRoomOrThrow(Long roomId) {
         return roomRepository.findById(roomId)
                 .orElseThrow(() -> new NoSuchElementException("Room not found with id : " + roomId));
     }
+
     private void deleteUserChatRoom(Long roomId) {
         userChatRoomCommandService.leaveUserChatRoomByChatRoomId(roomId);
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,7 +6,7 @@ spring: #띄어쓰기 없음
     driver-class-name: org.h2.Driver
   jpa: #띄어쓰기 2칸
     hibernate: #띄어쓰기 4칸
-      ddl-auto: create #띄어쓰기 6칸
+      ddl-auto: create-drop #띄어쓰기 6칸
     properties: #띄어쓰기 4칸
       hibernate: #띄어쓰기 6칸
         show_sql: true #띄어쓰기 8칸


### PR DESCRIPTION
#36 

```
@Override
    public void deleteRoom(Long roomId) {
        ChatRoom chatRoom = getChatRoomOrThrow(roomId);
        deleteUserChatRoom(roomId);
        roomRepository.delete(chatRoom);
    }
```
chat_room이랑 user_chat_room 테이블 관계에서 PK 값이 user_chat_room에 있는데 chat_room을 삭제를 먼저하려해서 400 에러 떴었다. PK 값을 가진 user_chat_room 테이블을 먼저 지우고 chat_room을 지워야 한다.